### PR TITLE
chore: extend browser no activity timeout to 90sec from 60sec.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -43,7 +43,7 @@ module.exports = (config) => {
     options.junitReporter = { outputDir: 'junit' };
     options.coverageReporter = { type: 'lcovonly', dir: 'coverage' };
     options.reporters = ['coverage', 'junit', 'dots'];
-    options.browserNoActivityTimeout = 60000;
+    options.browserNoActivityTimeout = 90000;
     options.client = { mocha: { timeout: 10000 } };
     options.browsers = [];
     if (process.env.CIRCLE_BRANCH === 'master') {


### PR DESCRIPTION
because some versions of IE and Edge don't response for a long time.