### PR TITLE
Named object3d

### DIFF
--- a/src/core/vgl-object3d.js
+++ b/src/core/vgl-object3d.js
@@ -76,7 +76,10 @@ export default {
           receiveShadow: this.receiveShadow,
           visible: this.visible,
         });
-        if (this.name !== undefined) this.vglNamespace.object3ds[this.name] = inst;
+        if (this.name !== undefined) {
+          this.inst.name = this.name;
+          this.vglNamespace.object3ds[this.name] = inst;
+        }
       },
       immediate: true,
     },
@@ -92,6 +95,7 @@ export default {
     name(name, oldName) {
       const { vglNamespace: { object3ds }, inst } = this;
       if (object3ds[oldName] === inst) delete object3ds[oldName];
+      this.inst.name = this.name;
       object3ds[name] = inst;
     },
     visible(visible) { this.inst.visible = visible; },

--- a/src/core/vgl-object3d.js
+++ b/src/core/vgl-object3d.js
@@ -95,7 +95,7 @@ export default {
     name(name, oldName) {
       const { vglNamespace: { object3ds }, inst } = this;
       if (object3ds[oldName] === inst) delete object3ds[oldName];
-      this.inst.name = this.name;
+      this.inst.name = name;
       object3ds[name] = inst;
     },
     visible(visible) { this.inst.visible = visible; },

--- a/src/core/vgl-object3d.js
+++ b/src/core/vgl-object3d.js
@@ -77,7 +77,8 @@ export default {
           visible: this.visible,
         });
         if (this.name !== undefined) {
-          this.inst.name = this.name;
+          // eslint-disable-next-line no-param-reassign
+          inst.name = this.name;
           this.vglNamespace.object3ds[this.name] = inst;
         }
       },

--- a/test/core/vgl-object3d.spec.js
+++ b/test/core/vgl-object3d.spec.js
@@ -132,4 +132,14 @@ describe('VglObject3d', () => {
     child.$destroy();
     expect(vm.inst.children).not.toContain(child.inst);
   });
+  test('the instance should have the name applied on ThreeJS Object inst', () => {
+    const { inst } = new (Vue.extend(VglObject3d))({ inject, propsData: { name: 'test' } });
+    expect(inst.name).toBe('test');
+  });
+  test('the properties "name" of the instance should change after props change', async () => {
+    const vm = new (Vue.extend(VglObject3d))({ inject, propsData: { name: 'test' } });
+    vm.name = 'newName';
+    await vm.$nextTick();
+    expect(vm.inst.name).toBe('newName');
+  });
 });


### PR DESCRIPTION
I realized that the object3d component doesn't apply the name props to the native ThreeJS Object3D (inst)
Having this name set is really convenient especially for Raytracing.

This PR basically apply the name on init and on change of the component prop 'name' to the inst object