### PR TITLE
Fix errors on document example pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -15,7 +15,6 @@ defaults:
       path: examples
     values:
       layout: example
-      search_enabled: false
       nav_exclude: true
 exclude:
   - rollup.config.js

--- a/docs/_layouts/example.html
+++ b/docs/_layouts/example.html
@@ -1,6 +1,6 @@
-<!DOCTYPE html>
-<html lang="{{ site.lang | default: 'en-US' }}">
-{% include head.html %}
+---
+layout: default
+---
 <script src="{{ '/js/vue.min.js' | relative_url }}"></script>
 <script src="{{ '/js/three.min.js' | relative_url }}"></script>
 <script src="{{ '/js/vue-gl.js' | relative_url }}"></script>
@@ -9,5 +9,9 @@
     Vue.component(key, VueGL[key]);
   });
 </script>
-<body class="example">
+<script type="text/javascript">
+  document.addEventListener('DOMContentLoaded', () => {
+    document.body.classList.add('example');
+  });
+</script>
 {{ content }}

--- a/docs/_sass/overrides.scss
+++ b/docs/_sass/overrides.scss
@@ -3,6 +3,19 @@ body.example {
   padding: 0;
   overflow: hidden;
 
+  .side-bar, .page-header {
+    display: none;
+  }
+
+  .main-content {
+    margin: 0;
+    max-width: initial;
+
+    .page {
+      padding: 0;
+    }
+  }
+
   .control-panel {
     background: #fff;
     left: 1ex;


### PR DESCRIPTION
Error occurs because the header element does not exist on example layout.
Changing layout to use for example pages.