### PR TITLE
Importing example component modules

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -7,8 +7,40 @@ nav_order: D
 ## Trying example components
 
 Each example components are built standalone under the [dist/js/examples](https://unpkg.com/browse/vue-gl/dist/examples/).
-To use them, load scripts directly with `<script>` element after loading VueGL or
-import with module bundlers.
 
-When load scripts directly, the component will be injected under the `VueGL` namespace.
-Resister `VueGL.<ComponentName>` to `Vue` before instantiating the components.
+### Load with \<script> tag
+If you are loading `VueGL` and dependencies directly in the browser with `<script>` element, example
+components also can be loaded in the same way.
+
+The loaded example components will be injected under the `VueGL` namespace.
+Resister the loaded components to `Vue` before using them just like the basic components.
+
+The example code below loads and registers the `VglObjLoader` component.
+```html
+<script src="/path/to/vue-gl/examples/loaders/vgl-obj-loader.js"></script>
+<script>
+  Vue.component('VglObjLoader', VueGL.VglObjLoader);
+</script>
+```
+Now you can use the `<vgl-obj-loader>` component in your Vue templates.
+
+Typically you also need to load and register the `VueGL` basic components to render the example
+components. In this case, the only thing you have to do is loading the example component scripts
+just before registering components.
+```html
+<script src="/path/to/vue.min.js"></script>
+<script src="/path/to/three.min.js"></script>
+<script src="/path/to/vue-gl.js"></script>
+<script src="/path/to/vue-gl/examples/loaders/vgl-obj-loader.js"></script>
+<script>
+  Object.keys(VueGL).forEach((name) => Vue.component(name, VueGL[name]));
+</script>
+```
+
+### Using npm
+Example components also can be handled by module bundlers. Just import and register from the
+dist/examples directory.
+```js
+const VglObjLoader = require('vue-gl/dist/examples/loaders/vgl-obj-loader');
+Vue.component('VglObjLoader', VglObjLoader);
+```

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -9,24 +9,27 @@ nav_order: D
 Each example components are built standalone under the [dist/js/examples](https://unpkg.com/browse/vue-gl/dist/examples/).
 
 ### Load with \<script> tag
-If you are loading `VueGL` and dependencies directly in the browser with `<script>` element, example
-components also can be loaded in the same way.
+If you are loading `VueGL` and dependencies directly in the browser with `<script>`
+element, example components also can be loaded in the same way.
 
 The loaded example components will be injected under the `VueGL` namespace.
 Resister the loaded components to `Vue` before using them just like the basic components.
 
 The example code below loads and registers the `VglObjLoader` component.
+
 ```html
 <script src="/path/to/vue-gl/examples/loaders/vgl-obj-loader.js"></script>
 <script>
   Vue.component('VglObjLoader', VueGL.VglObjLoader);
 </script>
 ```
+
 Now you can use the `<vgl-obj-loader>` component in your Vue templates.
 
-Typically you also need to load and register the `VueGL` basic components to render the example
-components. In this case, the only thing you have to do is loading the example component scripts
-just before registering components.
+Typically you also need to load and register the `VueGL` basic components to render
+the example components. In this case, the only thing you have to do is loading the
+example component scripts just before registering components.
+
 ```html
 <script src="/path/to/vue.min.js"></script>
 <script src="/path/to/three.min.js"></script>
@@ -38,8 +41,9 @@ just before registering components.
 ```
 
 ### Using npm
-Example components also can be handled by module bundlers. Just import and register from the
-dist/examples directory.
+Example components also can be handled by module bundlers. Just import and register
+from the dist/examples directory.
+
 ```js
 const VglObjLoader = require('vue-gl/dist/examples/loaders/vgl-obj-loader');
 Vue.component('VglObjLoader', VglObjLoader);

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -96,6 +96,7 @@ async function rollup() {
       file: `dist/${path}`,
       format: 'umd',
       globals: { [require.resolve('three/build/three.module')]: 'THREE', three: 'THREE' },
+      paths: {[require.resolve('three/build/three.module')]: 'three'},
       name: `VueGL.${componentName(name)}`,
     },
     plugins: [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -96,7 +96,7 @@ async function rollup() {
       file: `dist/${path}`,
       format: 'umd',
       globals: { [require.resolve('three/build/three.module')]: 'THREE', three: 'THREE' },
-      paths: {[require.resolve('three/build/three.module')]: 'three'},
+      paths: { [require.resolve('three/build/three.module')]: 'three' },
       name: `VueGL.${componentName(name)}`,
     },
     plugins: [


### PR DESCRIPTION
This PR enables the example components to be loaded as modules.
Each example component is exported on that module and can be handled by module bundlers.

Resolves #932 